### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://sid19sw.visualstudio.com/7ca71d10-10c2-4952-8fdf-43fde5995823/3043cb2d-76ad-43a0-8690-798a04e3ec69/_apis/work/boardbadge/cf31357b-bbfa-4dce-9ba3-0b3c3d8c1f1d)](https://sid19sw.visualstudio.com/7ca71d10-10c2-4952-8fdf-43fde5995823/_boards/board/t/3043cb2d-76ad-43a0-8690-798a04e3ec69/Microsoft.RequirementCategory)
 # MS-Workshops
 
 ### Welcome. This repository contains code samples and resources (if any) focused on Microsoft and OSS technologies.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#5. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.